### PR TITLE
Added the return types to class methods that override SplSubject

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ $ composer require fabiomsouto/phuse
 
 This project follows [semantic versioning](http://semver.org).
 
+### 2.0.0
+[Changed] 
+- Added the return types to class methods that override SplSubject methods to avoid E_DEPRECATED notices in php8.1, as the method signatures need to be equal to be considered compatible.
+
 ### 1.1.0
 [Added]
 - Compatibility with PHP7

--- a/src/UnsafeAPCFuse.php
+++ b/src/UnsafeAPCFuse.php
@@ -219,7 +219,7 @@ class UnsafeAPCFuse implements Fuse
      * @return void
      * @since 5.1.0
      */
-    public function attach(SplObserver $observer)
+    public function attach(SplObserver $observer): void
     {
         $this->observers->attach($observer);
     }
@@ -233,7 +233,7 @@ class UnsafeAPCFuse implements Fuse
      * @return void
      * @since 5.1.0
      */
-    public function detach(SplObserver $observer)
+    public function detach(SplObserver $observer): void
     {
         $this->observers->detach($observer);
     }
@@ -244,7 +244,7 @@ class UnsafeAPCFuse implements Fuse
      * @return void
      * @since 5.1.0
      */
-    public function notify()
+    public function notify(): void
     {
         foreach($this->observers as $observer) {
             $observer->update($this);


### PR DESCRIPTION
Added the return types to class methods that override SplSubject methods to avoid E_DEPRECATED notices in php8.1